### PR TITLE
chore(deps): bump diffusers floor to >=0.38.0, pytest to >=9.0.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "ComfyUI custom nodes for AlphaVAE — native RGBA transparent ima
 license = "MIT"
 requires-python = ">=3.10"
 dependencies = [
-    "diffusers>=0.33.0",
+    "diffusers>=0.38.0",
     "torch",
     "safetensors",
 ]
@@ -15,7 +15,7 @@ Repository = "https://github.com/katsut/ComfyUI-AlphaVAE"
 
 [dependency-groups]
 dev = [
-    "pytest>=8.0",
+    "pytest>=9.0.3",
 ]
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
## What
Raises declared dependency floors in `pyproject.toml` to non-vulnerable versions.

| dep | before | after | fixes |
|---|---|---|---|
| diffusers | >=0.33.0 | **>=0.38.0** | trust_remote_code/custom_pipeline RCE (CVE-2026-44513 / 44827 / 45804) |
| pytest (dev) | >=8.0 | **>=9.0.3** | tmpdir handling (CVE-2025-71176) |

## Why
OSV scan (2026-06) flagged advisories in the resolved dependency set. Since `uv.lock` is gitignored, the **declared floors** are the durable lever — bumping them prevents a fresh install from pulling a vulnerable version.

Note: this node only calls `AutoencoderKL.from_pretrained()` on a local directory (no `trust_remote_code`, no `custom_pipeline`), so the diffusers RCE class is not reachable via this code path; the bump is defense-in-depth.

## Verification
- Local lock refreshed (`uv lock --upgrade`) → diffusers 0.38.0 / pillow 12.2.0 / urllib3 2.7.0 / idna 3.18 / pytest 9.1.1
- Re-scanned with OSV → **0 known vulnerabilities**
- `uv run pytest` → **20 passed**

torch CVE-2025-3000 (jit.script) has no fixed release and `torch.jit.script` is unused here; left as-is (and the refreshed torch 2.12.1 no longer matches the advisory).

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)