### PR TITLE
ci: monthly pip-audit security scan + Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+updates:
+  # Python dependencies declared in pyproject.toml ([project.dependencies])
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps)"
+
+  # Actions used in .github/workflows/*
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    commit-message:
+      prefix: "ci(deps)"

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -1,0 +1,33 @@
+name: Security Audit
+
+on:
+  schedule:
+    # Monthly on the 1st at 06:00 UTC (low frequency)
+    - cron: "0 6 1 * *"
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  pip-audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Resolve and export dependencies
+        run: |
+          uv lock
+          uv export --frozen --no-hashes --no-emit-project --format requirements-txt > requirements.txt
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Audit dependencies (OSV / PyPI Advisory DB)
+        run: |
+          python -m pip install --quiet pip-audit
+          pip-audit -r requirements.txt --no-deps --desc


### PR DESCRIPTION
## What
Adds low-frequency, low-maintenance dependency security automation.

**`.github/workflows/security-audit.yml`** — scheduled scan (detection)
- Runs **monthly** (1st @ 06:00 UTC) + `workflow_dispatch` (manual)
- `uv` resolves & exports deps → `pip-audit` checks them against the OSV / PyPI Advisory DB
- Fails the job (→ notification) when a vulnerability is found
- `permissions: contents: read` only

**`.github/dependabot.yml`** — auto-fix (remediation)
- `pip` (reads `pyproject.toml` floors) + `github-actions`, **monthly**
- Opens PRs bumping deps to fixed versions; **merged by hand** (no auto-merge, since there's no test-gating CI yet)

## Notes
- `uv.lock` is gitignored, so Dependabot's `pip` ecosystem watches the declared floors in `pyproject.toml`; the pip-audit scan covers the full resolved tree.
- Can switch Dependabot to auto-merge later once a test CI exists.

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)